### PR TITLE
solve bug 1

### DIFF
--- a/src/endpoints/address.endpoint.ts
+++ b/src/endpoints/address.endpoint.ts
@@ -11,21 +11,21 @@ class AddressEndpoint extends baseEndpoint {
     }
 
     private count_post(req: Request, res: Response, next: NextFunction) {
-        addressService.count(req)
+        addressService.count(req.body)
             .then((response) => {
                 res.status(200).send(responseWrapper(RESPONSE_STATUS_OK, RESPONSE_EVENT_READ, response));
             }).catch((err) => {
-                res.status(400).send(responseWrapper(RESPONSE_STATUS_FAIL, RESPONSE_EVENT_READ, err));
-            });
+            res.status(400).send(responseWrapper(RESPONSE_STATUS_FAIL, RESPONSE_EVENT_READ, err));
+        });
     }
 
     private request_post(req: Request, res: Response, next: NextFunction) {
-        addressService.request(req)
+        addressService.request(req.body)
             .then((response) => {
                 res.status(200).send(responseWrapper(RESPONSE_STATUS_OK, RESPONSE_EVENT_READ, response));
             }).catch((err) => {
-                res.status(400).send(responseWrapper(RESPONSE_STATUS_FAIL, RESPONSE_EVENT_READ, err));
-            });
+            res.status(400).send(responseWrapper(RESPONSE_STATUS_FAIL, RESPONSE_EVENT_READ, err));
+        });
     }
 }
 

--- a/src/endpoints/address.endpoint.ts
+++ b/src/endpoints/address.endpoint.ts
@@ -14,9 +14,15 @@ class AddressEndpoint extends baseEndpoint {
         addressService.count(req.body)
             .then((response) => {
                 res.status(200).send(responseWrapper(RESPONSE_STATUS_OK, RESPONSE_EVENT_READ, response));
-            }).catch((err) => {
-            res.status(400).send(responseWrapper(RESPONSE_STATUS_FAIL, RESPONSE_EVENT_READ, err));
-        });
+            })
+            .catch((err) => {
+                const message = err.message || 'Internal Server Error';
+                const statusCode = message.includes('Missing required search') ? 400 :
+                    message.includes('Unexpected response') ? 500 :
+                        message.includes('Failed to fetch') ? 503 : 500;
+
+                res.status(statusCode).send(responseWrapper(RESPONSE_STATUS_FAIL, RESPONSE_EVENT_READ, { message }));
+            });
     }
 
     private request_post(req: Request, res: Response, next: NextFunction) {

--- a/src/services/address.service.ts
+++ b/src/services/address.service.ts
@@ -8,19 +8,13 @@ class AddressService {
     public async count(addressRequest?: any): Promise<any> {
         return new Promise<any>(async (resolve, reject) => {
             if (!addressRequest.city && !addressRequest.zip) {
-                return reject({
-                    status: 400,
-                    message: 'Missing required search field. Please provide at least a city or zip.'
-                });
+                return reject(new Error('Missing required search field. Please provide at least a city or zip.'));
             }
 
             this.request(addressRequest)
                 .then((response) => {
                     if (!Array.isArray(response)) {
-                        return reject({
-                            status: 500,
-                            message: 'Unexpected response from address API'
-                        });
+                        return reject(new Error('Unexpected response from address API'));
                     }
 
                     if (response.length === 0) {
@@ -35,7 +29,7 @@ class AddressService {
                     });
                 })
                 .catch((err) => {
-                    reject(err);
+                    reject(new Error('Failed to fetch from address API'));
                 });
         });
     }
@@ -48,8 +42,7 @@ class AddressService {
                 body: JSON.stringify(addressRequest)
             })
                 .then(async (response) => {
-                    const data = await response.json();
-                    resolve(data);
+                    resolve(await response.json());
                 })
                 .catch((err) => {
                     loggerService.error({ path: "/address/request", message: `${(err as Error).message}` }).flush();

--- a/src/services/address.service.ts
+++ b/src/services/address.service.ts
@@ -7,10 +7,31 @@ class AddressService {
 
     public async count(addressRequest?: any): Promise<any> {
         return new Promise<any>(async (resolve, reject) => {
+            if (!addressRequest.city && !addressRequest.zip) {
+                return reject({
+                    status: 400,
+                    message: 'Missing required search field. Please provide at least a city or zip.'
+                });
+            }
+
             this.request(addressRequest)
                 .then((response) => {
+                    if (!Array.isArray(response)) {
+                        return reject({
+                            status: 500,
+                            message: 'Unexpected response from address API'
+                        });
+                    }
+
+                    if (response.length === 0) {
+                        return resolve({
+                            count: 0,
+                            note: 'No results found for this query.'
+                        });
+                    }
+
                     resolve({
-                        "count": response.size()
+                        count: response.length
                     });
                 })
                 .catch((err) => {
@@ -23,10 +44,12 @@ class AddressService {
         return new Promise<any>(async (resolve, reject) => {
             fetch(AddressService.fetchUrl, {
                 method: "POST",
-                body: JSON.stringify(addressRequest.body)
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(addressRequest)
             })
                 .then(async (response) => {
-                    resolve(await response.json());
+                    const data = await response.json();
+                    resolve(data);
                 })
                 .catch((err) => {
                     loggerService.error({ path: "/address/request", message: `${(err as Error).message}` }).flush();


### PR DESCRIPTION
**Bug Fixed:**
Resolved the issue where the `/address/count` endpoint was not working as expected. The endpoint now correctly:
- Receives a POST request with a valid JSON body
- Sends the body to the external address API
- Counts and returns the number of matching results

**Improvements Made:**
- Fixed the improper usage of `req` by passing only `req.body` to the service
- Handled unexpected API responses with a meaningful error
- Added validation to return a `400 Bad Request` if neither `city` nor `zip` is provided in the body
- Enhanced empty responses with a helpful note when no results are found

**How to Test:**
1. Launch the app (see instructions in `README.md`)
2. Send a POST request to:
`http://localhost:{PORT}/address/count`
3. Include a valid JSON body like:
`json
{
  "city": "Rochester"
}
`
4. The response will include the count of addresses matching your query.

If no body is provided, the server will now respond with a `400` and a helpful message.