### PR TITLE
fixed bug 2

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -5,6 +5,21 @@ import { ENV } from './constants/environment-vars.constants';
 
 const router = express.Router();
 
+// Middleware to handle invalid endpoints
+router.use((req: Request, res: Response, next: NextFunction) => {
+    try {
+        const path = getEndpointControllerPath(req);
+        next();
+    } catch (err) {
+        res.status(404).json({
+            error: {
+                status: 404,
+                message: "Endpoint not found"
+            }
+        });
+    }
+});
+
 router.get('*', (req: Request, res: Response, next: NextFunction) => {
     (require(getEndpointControllerPath(req))).getRoute(req, res, next);
 });
@@ -27,7 +42,7 @@ function getEndpointControllerPath(req: Request): string {
     const ext = (ENV === 'dev') ? 'ts' : 'js';
     const route = `${__dirname}/endpoints/${paths[1]}.endpoint.${ext}`;
     if (paths.length === 1 || !fs.existsSync(route) || paths[1] == 'base') {
-        throw new createHttpError.BadRequest();
+        throw new Error("Invalid endpoint");
     }
 
     return route;


### PR DESCRIPTION
Key changes made:

    1. Added a middleware at the beginning that checks if the endpoint is valid before processing any requests
    2. Modified the error handling to return a 404 status with a JSON response instead of throwing an exception
    3. Simplified the error thrown in getEndpointControllerPath since we're handling it in the middleware
    4. The response now clearly indicates that the endpoint wasn't found

This change ensures that:

    - The app won't crash when invalid endpoints are accessed
    - Users get a clear, JSON-formatted error message
    - The response status code is appropriate (404 Not Found)
    - The error is handled gracefully without exposing internal error details

The error handling in app.ts will still catch any other unexpected errors (500 errors), but now 404 errors are handled specifically.