### PR TITLE
Feature 1: Implement Distance Calculation Between Two Points

### DIFF
--- a/src/endpoints/address.endpoint.ts
+++ b/src/endpoints/address.endpoint.ts
@@ -33,6 +33,18 @@ class AddressEndpoint extends baseEndpoint {
             res.status(400).send(responseWrapper(RESPONSE_STATUS_FAIL, RESPONSE_EVENT_READ, err));
         });
     }
+
+    private distance_post(req: Request, res: Response, next: NextFunction) {
+        addressService.distance(req.body)
+            .then((response) => {
+                res.status(200).send(responseWrapper(RESPONSE_STATUS_OK, RESPONSE_EVENT_READ, response));
+            })
+            .catch((err) => {
+                const message = err.message || 'Internal Server Error';
+                const statusCode = message.includes('Missing coordinates') ? 400 : 500;
+                res.status(statusCode).send(responseWrapper(RESPONSE_STATUS_FAIL, RESPONSE_EVENT_READ, { message }));
+            });
+    }
 }
 
 const addressEndpoint = new AddressEndpoint();

--- a/src/services/address.service.ts
+++ b/src/services/address.service.ts
@@ -52,35 +52,46 @@ class AddressService {
     }
 
     public async distance(addressRequest?: any): Promise<any> {
-        // Complete this
+        return new Promise<any>((resolve, reject) => {
+            const {
+                lat1, lon1,
+                lat2, lon2,
+                unit
+            } = addressRequest || {};
+
+            if (!lat1 || !lon1 || !lat2 || !lon2) {
+                return reject(new Error('Missing coordinates. Required: lat1, lon1, lat2, lon2.'));
+            }
+
+            const toRadians = (degrees: number) => degrees * (Math.PI / 180);
+
+            const R = 6371;
+            const dLat = toRadians(parseFloat(lat2) - parseFloat(lat1));
+            const dLon = toRadians(parseFloat(lon2) - parseFloat(lon1));
+
+            const a =
+                Math.sin(dLat / 2) ** 2 +
+                Math.cos(toRadians(parseFloat(lat1))) * Math.cos(toRadians(parseFloat(lat2))) *
+                Math.sin(dLon / 2) ** 2;
+
+            const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+            const distanceInKm = R * c;
+            const distanceInMi = distanceInKm * 0.621371;
+
+            let result: any = {
+                km: parseFloat(distanceInKm.toFixed(2)),
+                mi: parseFloat(distanceInMi.toFixed(2))
+            };
+
+            if (unit === 'km') {
+                result = { km: result.km };
+            } else if (unit === 'mi') {
+                result = { mi: result.mi };
+            }
+
+            resolve({ distance: result });
+        });
     }
-
-    // private async getDistance(lat1: string, lon1: string, lat2: string, lon2: string) {
-    //     // Defining this function inside of this private method means it's
-    //     // not accessible outside of it, which is perfect for encapsulation.
-    //     const toRadians = (degrees: string) => {
-    //         return degrees * (Math.PI / 180);
-    //     }
-
-    //     // Radius of the Earth in KM
-    //     const R = 6371;
-
-    //     // Convert Lat and Longs to Radians
-    //     const dLat = toRadians(lat2 - lat1);
-    //     const dLon = toRadians(lon2 - lon1);
-
-    //     // Haversine Formula to calculate the distance between two locations
-    //     // on a sphere.
-    //     const a =
-    //         Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-    //         Math.cos(toRadians(lat1)) * Math.cos(toRadians(lat2)) *
-    //         Math.sin(dLon / 2) * Math.sin(dLon / 2);
-
-    //     const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-
-    //     // convert and return distance in KM
-    //     return R * c;
-    // }
 }
 
 export default new AddressService();


### PR DESCRIPTION
**Summary: Implement the distance() function in address.service.ts**

**Description**
- Accept two coordinates (lat/lon pairs)
- Return the distance in: both kilometers and miles, or just KM or Mi based on a provided unit flag
- Follow best practices and wrap everything in a single response object

**What I've done**
- Add an endpoint named `distance_post`
- Add the method named `distance()`

**How to Test the Distance Endpoint**

1. Open Postman and set the method to `POST`.
2. Use the following URL (replace `{PORT}` with your local port):
   ```
   http://localhost:{PORT}/address/distance
   ```
3. In the body, use raw JSON (Content-Type: `application/json`) with the following structure:

   ```json
   {
     "lat1": "43.084847",
     "lon1": "-77.674194",
     "lat2": "40.712776",
     "lon2": "-74.005974",
     "unit": "mi"
   }
   ```

4. The `unit` field is optional:
   - If set to `"mi"` or `"km"`, the response will include only the specified unit.
   - If omitted, the response will include **both** miles and kilometers.