### PR TITLE
Feature 3: Implement a Custom Feature

### DIFF
--- a/src/services/address.service.ts
+++ b/src/services/address.service.ts
@@ -41,16 +41,29 @@ class AddressService {
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify(addressRequest)
             })
-                .then(async (response) => {
-                    resolve(await response.json());
-                })
-                .catch((err) => {
-                    loggerService.error({ path: "/address/request", message: `${(err as Error).message}` }).flush();
-                    reject(err);
-                });
+            .then(async (response) => {
+                let result = await response.json();
+    
+                if (!Array.isArray(result)) {
+                    return reject(new Error('Unexpected response from address API'));
+                }
+
+                const { page, limit } = addressRequest;
+                if (page !== undefined && limit !== undefined) {
+                    const startIndex = (page - 1) * limit;
+                    const endIndex = startIndex + limit;
+                    result = result.slice(startIndex, endIndex);
+                }
+    
+                resolve(result);
+            })
+            .catch((err) => {
+                loggerService.error({ path: "/address/request", message: `${(err as Error).message}` }).flush();
+                reject(err);
+            });
         });
     }
-
+    
     public async distance(addressRequest?: any): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             const {


### PR DESCRIPTION
**Summary: Implement pagination support in address.service.ts for the /address/request endpoint.**

**Description**
- Accept optional `page` and `limit` fields in the request body
- If provided, return only a subset of the full address list:
  - `page` determines which group of results is retrieved (starting from 1)
  - `limit` determines how many addresses are included per page
- If `page` and `limit` are omitted, return the full list of addresses (backward compatible)
- Added runtime type checking (`Array.isArray`) to ensure safe processing of results from the external address API

**What I've done**
- Updated the `request()` method inside `address.service.ts` to support pagination.
- Applied runtime validation to ensure results are arrays before slicing.

**How to Test the Paginated Address Endpoint**

1. Open Postman and set the method to `POST`.
2. Use the following URL (replace `{PORT}` with your local port):
   ```
   http://localhost:{PORT}/address/request
   ```
3. In the body, use raw JSON (Content-Type: `application/json`) with the following structure:

   ```json
   {
     "city": "Rochester",
     "zip": "14623",
     "page": 2,
     "limit": 5
   }
   ```
4. The `page` and `limit` fields are optional:
   - If you omit `page` and `limit`, all results will be returned as before.
   - If you specify `page` and `limit`, only the requested slice of results will be returned.
5. `page` numbering starts at 1 (not 0)
   - If the requested page exceeds available results, an empty array will be returned safely.